### PR TITLE
chore(ci): remove unused Jenkins pipeline

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -1,2 +1,0 @@
-@Library("camunda-ci") _
-buildMavenAndDeployToMavenCentral([jdk: 8, extraJdks: ['jdk-7-latest'], mvn: 3.5])


### PR DESCRIPTION
This was added in https://github.com/camunda-community-hub/camunda-platform-scenario/pull/30 originally before move to Community Hub. Since then, this Jenkins pipeline is unused.